### PR TITLE
fix: unref the purge interval so it never keeps the process alive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+`@acfatah/memory-cache` is a dependency-free, in-memory TTL cache for Bun and Node.js, published to npm as an ESM-only library. The entire public surface is a single factory, `useMemoryCache()`.
+
+## Toolchain
+
+Bun is the runtime, package manager, test runner, and bundler — there is no npm/pnpm, Jest, Vite, or tsc-based build here. Requires Bun `>=1.2.18` and Node `>=22`. The pinned Bun version lives in `.bun-version` (consumed by CI and by `build`).
+
+## Commands
+
+```bash
+bun install              # install deps
+
+bun test                 # run all tests
+bun test tests/memory-cache.spec.ts   # run a single test file
+bun test -t "should purge"            # run tests matching a name pattern
+bun test:watch           # watch mode
+bun test:coverage        # emit coverage/lcov.info (what CI uploads)
+
+bun typecheck            # tsc --noEmit (type-check only; no build output)
+bun lint                 # eslint over the repo
+bun format               # eslint --fix
+bun lint:changed         # eslint only files changed vs HEAD (untracked included)
+
+bun run build            # bundle src/ -> dist/ (ESM .mjs + .d.ts)
+bun run release          # build, then interactive version bump + git tag (bumpp)
+```
+
+`precommit` (`bun run typecheck && bun run lint:staged`) and commit-message linting run automatically via `simple-git-hooks`; commits must follow Conventional Commits (`@commitlint/config-conventional`).
+
+## Architecture — the one thing to know first
+
+**Cache storage is a module-level global singleton, not per-instance.** In `src/memory-cache.ts`, `cacheStorage` (a `Map`), `purgeIntervalId`, and `purgeTimeout` are declared at module scope — _outside_ `useMemoryCache()`. Every call to `useMemoryCache()` returns fresh closures (`get`/`set`/`keys`/…) but they all read and write the **same** underlying `Map`.
+
+Consequences that are easy to get wrong:
+
+- Two `useMemoryCache()` instances share one keyspace and collide on identical keys.
+- `clear()`, `purge()`, `keys()` operate globally regardless of which instance called them.
+- `setPurgeTimeout()` reconfigures the single shared interval for all callers (the README calls this out).
+- The generic `useMemoryCache<CacheSchema>()` parameter is **purely compile-time type inference** for key/value types — it does _not_ namespace or isolate storage at runtime.
+- Tests rely on this: `beforeEach` constructs an instance and calls `clear()` to reset the shared global between cases.
+
+## Cache semantics
+
+- **`ttl` is stored as an absolute expiry timestamp**, not a remaining duration. `set` computes `Date.now() + ttl` and stores it in `CacheEntry.ttl`. A `ttl` of `null` becomes `Infinity` (never expires) — so despite the `number | null` type, stored entries always hold a numeric timestamp, never `null`.
+- **Two-layer expiration.** `get` lazily evicts on read when an entry is past its timestamp; a background `setInterval` (default 1 minute) runs `purge()` to sweep expired entries proactively. The interval is created lazily on first `useMemoryCache()` call.
+- **`set(key, undefined)` is delete** — passing `undefined` as the value removes the key (used as an invalidation idiom in the README/tests). Default TTL is 5 minutes when the factory is given no `ttl`.
+- `__cacheStorage` is returned as an intentional, `@ts-expect-error`-hidden escape hatch used only by tests to assert on the raw `Map`.
+
+## Build & release flow
+
+- `scripts/build.ts` uses `Bun.build` with `bun-plugin-dts` to emit `dist/index.mjs` + `dist/index.d.ts`. Output is **ESM-only** — `package.json` `exports` expose only `import`/`types`, no CommonJS build.
+- Source uses the `@/*` -> `./src/*` path alias (see `tsconfig.json`); tests import via `@/index`.
+- Pushing a `v*` tag triggers `.github/workflows/release.yml` (generates the GitHub release + changelog via `changelogithub`); publishing that GitHub release triggers `.github/workflows/publish.yml` (`bun publish` to npm). `bun run release` is the local step that produces the tag.
+- A weekly workflow runs `bun update` and opens a dependency-bump PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Consequences that are easy to get wrong:
 ## Cache semantics
 
 - **`ttl` is stored as an absolute expiry timestamp**, not a remaining duration. `set` computes `Date.now() + ttl` and stores it in `CacheEntry.ttl`. A `ttl` of `null` becomes `Infinity` (never expires) — so despite the `number | null` type, stored entries always hold a numeric timestamp, never `null`.
-- **Two-layer expiration.** `get` lazily evicts on read when an entry is past its timestamp; a background `setInterval` (default 1 minute) runs `purge()` to sweep expired entries proactively. The interval is created lazily on first `useMemoryCache()` call.
+- **Two-layer expiration.** `get` lazily evicts on read when an entry is past its timestamp; a background `setInterval` (default 1 minute) runs `purge()` to sweep expired entries proactively. The interval is created lazily on first `useMemoryCache()` call and is `unref`'d in `createPurgeInterval()`, so it never keeps the process alive (a one-shot script/CLI that touches the cache still exits naturally).
 - **`set(key, undefined)` is delete** — passing `undefined` as the value removes the key (used as an invalidation idiom in the README/tests). Default TTL is 5 minutes when the factory is given no `ttl`.
 - `__cacheStorage` is returned as an intentional, `@ts-expect-error`-hidden escape hatch used only by tests to assert on the raw `Map`.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ clear()
 
 By default, the purge interval is set to 1 minute. To change it, use the `setPurgeTimeout` method. Note that this will affect all caches globally.
 
+The purge interval is `unref`'d, so it never keeps your process alive. A one-shot script, CLI, or cron job can import the cache and still exit naturally; in a long-running process the timer keeps firing as usual.
+
 To cache schema type inference,
 
 ```typescript

--- a/src/memory-cache.ts
+++ b/src/memory-cache.ts
@@ -34,7 +34,16 @@ let purgeIntervalId: NodeJS.Timer | null = null
 let purgeTimeout: number
 
 function createPurgeInterval(): NodeJS.Timer {
-  return setInterval(purge, purgeTimeout || ONE_MINUTES)
+  const timer = setInterval(purge, purgeTimeout || ONE_MINUTES)
+
+  // Never let the background purge timer keep the process alive. Without this a
+  // one-shot script/CLI/cron that touches the cache hangs forever, and a
+  // server's graceful shutdown never drains. Lazy eviction (`get`) and
+  // on-demand `purge()` are unaffected; a long-lived process keeps the loop
+  // alive via its own handles, so the timer still fires normally.
+  timer.unref?.()
+
+  return timer
 }
 
 /**

--- a/tests/memory-cache.spec.ts
+++ b/tests/memory-cache.spec.ts
@@ -208,3 +208,36 @@ describe('cache', () => {
     expect(cacheStorage.size).toBe(0)
   })
 })
+
+describe('process lifecycle', () => {
+  // Regression test for the purge timer keeping the event loop alive.
+  // Before the fix, importing the library and touching the cache installed a
+  // ref-ed setInterval that prevented the process from ever exiting on its own.
+  // The child below does a single set() and nothing else; if the purge timer is
+  // not unref-ed it never exits and this test times out.
+  it('should not keep the process alive after use', async () => {
+    const entry = `${import.meta.dir}/../src/index.ts`
+    const script = `import { useMemoryCache } from ${JSON.stringify(entry)}; useMemoryCache().set('k', 1)`
+    const proc = Bun.spawn({
+      cmd: ['bun', '-e', script],
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+
+    const TIMED_OUT = Symbol('timed-out')
+    let killer: ReturnType<typeof setTimeout>
+    const timeout = new Promise<typeof TIMED_OUT>((resolve) => {
+      killer = setTimeout(resolve, 8000, TIMED_OUT)
+    })
+
+    const outcome = await Promise.race([proc.exited, timeout])
+    clearTimeout(killer!)
+
+    if (outcome === TIMED_OUT) {
+      proc.kill()
+      throw new Error('process did not exit within 8s: the purge timer is keeping the event loop alive')
+    }
+
+    expect(outcome).toBe(0)
+  }, 15000)
+})


### PR DESCRIPTION
## Problem                                                                                   
                                                                                             
The background purge timer created by `createPurgeInterval()` was a ref-ed                   
`setInterval`. Once the first `useMemoryCache()` call installed it, the timer                
kept the event loop alive for the life of the process — with no API to stop it               
(`setPurgeTimeout()` only *re-creates* the interval).                                        
                                                                                             
Consequences for consumers:                                                                  
                                                                                             
- A one-shot script, CLI, or cron job that touches the cache **hangs forever**               
  instead of exiting.                                                                        
- A server's graceful shutdown never drains — the loop won't close on its own.               
- The only workarounds were `process.exit()` or never importing the library.                 
                                                                                             
Reproduction (hangs; killed by timeout, exit 124):                                           
                                                                                             
```bash                                                                                      
timeout 6 bun -e "import {useMemoryCache} from './src/index.ts'; useMemoryCache().set('k',1)"
```
                                                                                             
Fix                                                                                          
                                                                                             
Call timer.unref?.() inside createPurgeInterval() so the purge timer never                   
holds the event loop open on its own. Placing it there covers both the initial               
install and the setPurgeTimeout() recreation path.                                           
                                                                                             
Behaviour is otherwise unchanged:                                                            
                                                                                             
- Lazy eviction on get() and on-demand purge() are unaffected.                               
- In a long-lived process, other handles keep the loop alive, so the sweep keeps             
firing on schedule — unref() only permits exit when the timer is the last                    
thing holding the loop open.                                                                 
- The optional-chaining guard keeps it safe on runtimes where setInterval                    
returns a plain number.                                                                      
                                                                                             
After the fix, the reproduction above exits 0.                                               
                                                                                             
Tests & docs                                                                                 
                                                                                             
- New subprocess regression test (process lifecycle): imports the library,                   
does a single set(), and asserts the child exits 0 within a timeout — it                     
hangs without the fix.                                                                       
- Documented the behaviour in README.md and CLAUDE.md.                                       
                                                                                             
Full suite green (10/10), bun typecheck and bun lint clean.                                  
                                                                                             
Scope                                                                                        
                                                                                             
Addresses Issue 1 from the code-review audit. Related setPurgeTimeout                        
findings (Infinity→1ms clamp; setPurgeTimeout(0) swallow) and the optional                   
stopPurge() API were intentionally left out and can be follow-ups. 

Suggested and implemented with [Claude Code](https://claude.com/claude-code). 
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>                      